### PR TITLE
Verilator testbench for ISA tests

### DIFF
--- a/fpga/common.mk
+++ b/fpga/common.mk
@@ -7,7 +7,7 @@
 # - CONFIG
 # - FPGA_DIR
 
-CORE = e201
+CORE = e203
 PATCHVERILOG ?= ""
 
 
@@ -25,8 +25,7 @@ install:
 	sed -i '1i\`define FPGA_SOURCE\'  ${INSTALL_RTL}/core/${CORE}_defines.v
 
 EXTRA_FPGA_VSRCS := 
-verilog := $(wildcard ${INSTALL_RTL}/*/*.v)
-verilog += $(wildcard ${INSTALL_RTL}/*.v)
+verilog =$(wildcard ${INSTALL_RTL}/*/*.v ${INSTALL_RTL}/*.v)
 
 
 # Build .mcs
@@ -42,7 +41,7 @@ bit : install
 
 
 .PHONY: setup
-setup: 
+setup: install
 	BASEDIR=${base_dir} VSRCS="$(verilog)" EXTRA_VSRCS="$(EXTRA_FPGA_VSRCS)" $(MAKE) -C $(FPGA_DIR) setup
 
 

--- a/rtl/e203/core/e203_clkgate.v
+++ b/rtl/e203/core/e203_clkgate.v
@@ -46,7 +46,7 @@ module e203_clkgate (
 
 `ifndef FPGA_SOURCE//{
 
-reg enb;
+reg enb /*verilator clock_enable*/;
 
 always@(*)
   if (!clk_in)

--- a/rtl/e203/general/sirv_sim_ram.v
+++ b/rtl/e203/general/sirv_sim_ram.v
@@ -48,7 +48,7 @@ module sirv_sim_ram
   output [DW-1:0]   dout
 );
 
-    reg [DW-1:0] mem_r [0:DP-1];
+    reg [0:DP-1] [DW-1:0] mem_r;
     reg [AW-1:0] addr_r;
     wire [MW-1:0] wen;
     wire ren;

--- a/sirv-e-sdk/Makefile
+++ b/sirv-e-sdk/Makefile
@@ -108,20 +108,28 @@ toolchain_prefix := $(toolchain_builddir)/prefix
 
 RISCV_PATH ?= $(toolchain_prefix)
 
+ifeq ($(GCCVER),)
+RISCV_GCC     ?= $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-gcc)
+RISCV_GXX     ?= $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-g++)
+RISCV_OBJDUMP ?= $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-objdump)
+RISCV_GDB     ?= $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-gdb)
+RISCV_AR      ?= $(abspath $(RISCV_PATH)/bin/riscv64-unknown-elf-ar)
+endif
+
 ifeq ($(GCCVER),6)
-RISCV_GCC     := $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-gcc)
-RISCV_GXX     := $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-g++)
-RISCV_OBJDUMP := $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-objdump)
-RISCV_GDB     := $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-gdb)
-RISCV_AR      := $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-ar)
+RISCV_GCC     ?= $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-gcc)
+RISCV_GXX     ?= $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-g++)
+RISCV_OBJDUMP ?= $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-objdump)
+RISCV_GDB     ?= $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-gdb)
+RISCV_AR      ?= $(abspath $(RISCV_PATH)/bin/riscv32-unknown-elf-ar)
 endif
 
 ifeq ($(GCCVER),7)
-RISCV_GCC     := $(abspath $(RISCV_PATH)/bin/riscv-none-embed-gcc)
-RISCV_GXX     := $(abspath $(RISCV_PATH)/bin/riscv-none-embed-g++)
-RISCV_OBJDUMP := $(abspath $(RISCV_PATH)/bin/riscv-none-embed-objdump)
-RISCV_GDB     := $(abspath $(RISCV_PATH)/bin/riscv-none-embed-gdb)
-RISCV_AR      := $(abspath $(RISCV_PATH)/bin/riscv-none-embed-ar)
+RISCV_GCC     ?= $(abspath $(RISCV_PATH)/bin/riscv-none-embed-gcc)
+RISCV_GXX     ?= $(abspath $(RISCV_PATH)/bin/riscv-none-embed-g++)
+RISCV_OBJDUMP ?= $(abspath $(RISCV_PATH)/bin/riscv-none-embed-objdump)
+RISCV_GDB     ?= $(abspath $(RISCV_PATH)/bin/riscv-none-embed-gdb)
+RISCV_AR      ?= $(abspath $(RISCV_PATH)/bin/riscv-none-embed-ar)
 endif
 
 PATH := $(abspath $(RISCV_PATH)/bin):$(PATH)
@@ -198,6 +206,7 @@ PROGRAM_DIR = software/$(PROGRAM)
 PROGRAM_ELF = software/$(PROGRAM)/$(PROGRAM)
 
 .PHONY: software_clean
+clean: software_clean
 software_clean:
 	$(MAKE) -C $(PROGRAM_DIR) BSP_BASE=$(abspath bsp) BOARD=$(BOARD) clean
 

--- a/verilator/Makefile
+++ b/verilator/Makefile
@@ -1,0 +1,22 @@
+vdir = ../rtl/e203
+vsrc = tb_verilator.v $(foreach d,$(wildcard $(vdir)/*),$(wildcard $(d)/*.*v*))
+csrc = sim.cpp
+objdir = obj
+obj = $(csrc:%.cpp=%)
+vflags = --cc --exe --Mdir $(objdir) +incdir+$(vdir)/core +incdir+$(vdir)/perips \
+	 --top-module tb_verilator \
+	 -Wno-WIDTH -Wno-UNOPTFLAT -Wno-CASEINCOMPLETE -Wno-LITENDIAN
+vflags_extra = --trace
+
+
+.PHONY: all
+all: $(objdir)/$(obj)
+
+$(objdir)/$(obj): $(vsrc) $(csrc)
+	verilator $(vflags) $(vflags_extra) -o $(notdir $(obj)) $(csrc) $(vsrc)
+	make -C $(objdir) -f Vtb_verilator.mk
+
+.PHONY: clean
+clean:
+	rm -rf $(objdir)
+

--- a/verilator/Makefile
+++ b/verilator/Makefile
@@ -1,16 +1,65 @@
+# Copyright 2018 Tomas Brabec
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL=bash
+
 vdir = ../rtl/e203
 vsrc = tb_verilator.v $(foreach d,$(wildcard $(vdir)/*),$(wildcard $(d)/*.*v*))
 csrc = sim.cpp
+cflags =
 objdir = obj
 obj = $(csrc:%.cpp=%)
-vflags = --cc --exe --Mdir $(objdir) +incdir+$(vdir)/core +incdir+$(vdir)/perips \
+vflags = $(if $(cflags),-CFLAGS $(cflags)) --cc --exe --Mdir $(objdir) +incdir+$(vdir)/core +incdir+$(vdir)/perips \
 	 --top-module tb_verilator \
 	 -Wno-WIDTH -Wno-UNOPTFLAT -Wno-CASEINCOMPLETE -Wno-LITENDIAN
 vflags_extra = --trace
 
+isa_test_patts ?= rv32ui* rv32um* rv32uc* rv32ua* rv32mi*
+isa_test_dir ?= ../riscv-tools/riscv-tests/isa/generated
+isa_tests ?= $(basename $(notdir $(wildcard $(foreach p,$(isa_test_patts),$(isa_test_dir)/$(p).verilog))))
 
-.PHONY: all
-all: $(objdir)/$(obj)
+
+.PHONY: help
+help:
+	@echo -e "Usage:\n\tmake [ooptions] [target] [<variable>=<value>]"
+	@echo -e "\nTargets:"
+	@echo -e "  help        prints this help message"
+	@echo -e "  list-tests  lists available ISA tests"
+	@echo -e "  build       creates a testbench binary ($(objdir)/$(obj))"
+	@echo -e "  regression  runs all tests listed by 'list-tests'"
+	@echo -e "  test-<name> runs a single test"
+	@echo -e "  clean       delete all outputs"
+	@echo -e "\nVariables:"
+	@echo -e "  isa_test_patts   space separated list of patterns of ISA tests"
+	@echo -e "                   (actual: '$(isa_test_patts)')"
+	@echo -e "  isa_tests        space separated list of tests to run for 'regression',"
+	@echo -e "                   use 'make list' to display the corresponding list"
+	@echo -e "  cflags           extra C++ compiler flags"
+	@echo -e "                   use cflags='-DVCDTRACE=1' to enable VCD dump into dump.vcd file."
+	@echo -e "\nExamples:"
+	@echo -e "  make build test-rv32ui-p-xori"
+	@echo -e "  make regression isa_tests=rv32ui-p-xori"
+	@echo -e "  make regression isa_patts='rv32ui*'"
+	@echo -e ""
+
+.PHONY: list-tests list
+list list-tests:
+	@echo $(isa_tests)
+
+
+.PHONY: all build
+all build: $(objdir)/$(obj)
 
 $(objdir)/$(obj): $(vsrc) $(csrc)
 	verilator $(vflags) $(vflags_extra) -o $(notdir $(obj)) $(csrc) $(vsrc)
@@ -18,5 +67,12 @@ $(objdir)/$(obj): $(vsrc) $(csrc)
 
 .PHONY: clean
 clean:
-	rm -rf $(objdir)
+	rm -rf $(objdir) results dump.vcd && for f in *.verilog; do if [ -L $${f} ]; then unlink $${f}; fi; done
+
+.PHONY: regression
+regression: $(isa_tests:%=test-%)
+
+test-%: $(isa_test_dir)/%.verilog
+	@test -e $*.verilog || ln -s $<
+	@mkdir -p results && echo "Running '$*' test ..." && $(objdir)/$(obj) +TESTCASE=$* > results/$*.log
 

--- a/verilator/README.md
+++ b/verilator/README.md
@@ -1,0 +1,100 @@
+ISA Tests under Verilator
+=========================
+
+This folder contains a Verilator testbench to exercise RTL against ISA
+[riscv-tests](https://github.com/riscv/riscv-tests).
+
+The testbench was tested with Verilator 3.924 and should work out of the box
+with 3.922 (as the 1st version supporting SV `assert property`). For earlier
+versions one needs to verilate with `+define+DISABLE_SV_ASSERTIONS=1`.
+
+Limitations
+-----------
+
+- Regressions support pre-compiled versions of [riscv-tests](https://github.com/riscv/riscv-tests)
+  available in `riscv-tools/riscv-tests/isa/generated` folder.
+
+- Hard-coded number of clock cycles. The C++ testbench forces the simulation
+  to stop after 1024 cycles. This may be changed in `sim.cpp`.
+
+- The RTL code needs to be verilated with `--trace` option and a VCD trace
+  instance created in the C++ testbench. Otherwise the simulation does not
+  work/converge.
+
+Installing Verilator
+--------------------
+
+### Installing Packaged Version ###
+
+Instructions from https://github.com/ucb-bar/riscv-sodor
+
+- Ubuntu 17.04 and on
+
+      sudo apt install pkg-config verilator
+      
+- Ubuntu 16.04 and earlier
+
+      sudo apt install pkg-config
+      wget http://mirrors.kernel.org/ubuntu/pool/universe/v/verilator/verilator_3.900-1_amd64.deb
+      sudo dpkg -i verilator_3.900-1_amd64.deb
+
+### Building ###
+
+Instructions adapted from https://github.com/ucb-bar/riscv-sodor
+
+    # install packages needed for compilation
+    sudo apt-get install make autoconf g++ flex bison libfl-dev
+    
+    # optionally install GtkWave
+    sudo apt-get install gtkwave
+    
+    # obtain a released version
+    # (alternatively clone a git repo: http://git.veripool.org/git/verilator)
+    wget https://www.veripool.org/ftp/verilator-3.924.tgz
+    tar -xzf verilator-3.924.tgz
+    
+    # compile
+    # (when intending to install, consider using ./configure --prefix=<path>)
+    cd verilator*
+    unset VERILATOR_ROOT
+    ./configure && make
+    
+    # set environment
+    export VERILATOR_ROOT=$PWD
+    export PATH=$PATH:$VERILATOR_ROOT/bin
+
+Building
+--------
+
+To build with default settings:
+
+    make build
+
+To enable VCD dump into `dump.vcd`. Note that the dumping support is compiled
+into the testbench binary and hence you need to rebuild to turn it on and off.
+
+    make build cflags='-DVCDTRACE=1'
+
+To build with Verilator prior to 3.922:
+
+    make build vflags_extra='--trace +define+DISABLE_SV_ASSERTIONS=1'
+
+Running
+-------
+
+To run the supported regression test suite:
+
+    make regression
+
+To run a full regression test suite (including e.g. floating-point ISA tests):
+
+    make regression isa_test_patts='*'
+
+To run a single test:
+
+    # either run as a regression suite of one test
+    make regression isa_tests=rv32ui-p-xori
+    
+    # or run as a single test
+    make test-rv32ui-p-xori
+

--- a/verilator/README.md
+++ b/verilator/README.md
@@ -38,7 +38,7 @@ Instructions from https://github.com/ucb-bar/riscv-sodor
       wget http://mirrors.kernel.org/ubuntu/pool/universe/v/verilator/verilator_3.900-1_amd64.deb
       sudo dpkg -i verilator_3.900-1_amd64.deb
 
-### Building ###
+### Building from Source ###
 
 Instructions adapted from https://github.com/ucb-bar/riscv-sodor
 
@@ -63,8 +63,8 @@ Instructions adapted from https://github.com/ucb-bar/riscv-sodor
     export VERILATOR_ROOT=$PWD
     export PATH=$PATH:$VERILATOR_ROOT/bin
 
-Building
---------
+Building Testbench
+------------------
 
 To build with default settings:
 
@@ -77,7 +77,7 @@ into the testbench binary and hence you need to rebuild to turn it on and off.
 
 To build with Verilator prior to 3.922:
 
-    make build vflags_extra='--trace +define+DISABLE_SV_ASSERTIONS=1'
+    make build vflags_extra='--trace +define+DISABLE_SV_ASSERTION=1'
 
 Running
 -------

--- a/verilator/sim.cpp
+++ b/verilator/sim.cpp
@@ -1,0 +1,82 @@
+#include "Vtb_verilator.h"
+#include <verilated.h>
+
+#if VM_TRACE
+#include <verilated_vcd_c.h>
+#endif
+
+vluint64_t simtime = 0;       // Current simulation time
+				// This is a 64-bit integer to reduce wrap over issues and
+				// allow modulus.  You can also use a double, if you wish.
+
+double sc_time_stamp () {       // Called by $time in Verilog
+	return simtime;       // converts to double, to match
+				// what SystemC does
+}
+
+int main(int argc, char **argv, char **env) {
+	Verilated::commandArgs(argc, argv);
+	Vtb_verilator* top = new Vtb_verilator;
+	int cnt;
+	simtime = 0;
+
+#if VM_TRACE
+	Verilated::traceEverOn(true);
+        VerilatedVcdC* tfp = new VerilatedVcdC;
+//	top->trace (tfp, 99);
+//        tfp->open ("simx.vcd");
+#endif
+
+	// reset
+	top->rst_n = 1;
+	top->clk = 0;
+	top->eval();
+//#if VM_TRACE
+//	tfp->dump(simtime);
+//#endif
+	simtime++;
+	top->rst_n = 0;
+	top->eval();
+//#if VM_TRACE
+//	tfp->dump(simtime);
+//#endif
+	simtime++;
+	top->rst_n = 1;
+	top->eval();
+//#if VM_TRACE
+//	tfp->dump(simtime);
+//#endif
+	simtime++;
+
+	while (!Verilated::gotFinish() && cnt < (1 << 15)) {
+		top->clk = 1;
+		top->eval();
+//#if VM_TRACE
+//		tfp->dump(simtime);
+//#endif
+		simtime++;
+		top->clk = 0;
+		top->eval();
+//#if VM_TRACE
+//		tfp->dump(simtime);
+//#endif
+		simtime++;
+		cnt++;
+	}
+	delete top;
+
+#if VM_TRACE
+//	tfp->close();
+	delete tfp;
+#endif
+
+	if (!Verilated::gotFinish()) {
+		printf("Simulation time out! Forced stop ...\n");
+		return 1;
+	} else {
+#if VM_COVERAGE
+		VerilatedCov::write("coverage.dat");
+#endif // VM_COVERAGE
+		return 0;
+	}
+}

--- a/verilator/sim.cpp
+++ b/verilator/sim.cpp
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Tomas Brabec
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 #include "Vtb_verilator.h"
 #include <verilated.h>
 
@@ -23,50 +39,54 @@ int main(int argc, char **argv, char **env) {
 #if VM_TRACE
 	Verilated::traceEverOn(true);
         VerilatedVcdC* tfp = new VerilatedVcdC;
-//	top->trace (tfp, 99);
-//        tfp->open ("simx.vcd");
+#if VCDTRACE
+	top->trace (tfp, 99);
+        tfp->open ("dump.vcd");
+#endif
 #endif
 
 	// reset
 	top->rst_n = 1;
 	top->clk = 0;
 	top->eval();
-//#if VM_TRACE
-//	tfp->dump(simtime);
-//#endif
+#if VM_TRACE && VCDTRACE
+	tfp->dump(simtime);
+#endif
 	simtime++;
 	top->rst_n = 0;
 	top->eval();
-//#if VM_TRACE
-//	tfp->dump(simtime);
-//#endif
+#if VM_TRACE && VCDTRACE
+	tfp->dump(simtime);
+#endif
 	simtime++;
 	top->rst_n = 1;
 	top->eval();
-//#if VM_TRACE
-//	tfp->dump(simtime);
-//#endif
+#if VM_TRACE && VCDTRACE
+	tfp->dump(simtime);
+#endif
 	simtime++;
 
 	while (!Verilated::gotFinish() && cnt < (1 << 15)) {
 		top->clk = 1;
 		top->eval();
-//#if VM_TRACE
-//		tfp->dump(simtime);
-//#endif
+#if VM_TRACE && VCDTRACE
+		tfp->dump(simtime);
+#endif
 		simtime++;
 		top->clk = 0;
 		top->eval();
-//#if VM_TRACE
-//		tfp->dump(simtime);
-//#endif
+#if VM_TRACE && VCDTRACE
+		tfp->dump(simtime);
+#endif
 		simtime++;
 		cnt++;
 	}
 	delete top;
 
 #if VM_TRACE
-//	tfp->close();
+#if VCDTRACE
+	tfp->close();
+#endif
 	delete tfp;
 #endif
 

--- a/verilator/tb_verilator.v
+++ b/verilator/tb_verilator.v
@@ -1,0 +1,542 @@
+
+`include "e203_defines.v"
+
+module tb_verilator(
+
+  input wire  clk,
+  input wire  rst_n
+  );
+
+  `define CPU_TOP u_e203_soc_top.u_e203_subsys_top.u_e203_subsys_main.u_e203_cpu_top
+  `define EXU `CPU_TOP.u_e203_cpu.u_e203_core.u_e203_exu
+  `define ITCM `CPU_TOP.u_e203_srams.u_e203_itcm_ram.u_e203_itcm_gnrl_ram.u_sirv_sim_ram
+
+  `define PC_WRITE_TOHOST       `E203_PC_SIZE'h80000086
+  `define PC_EXT_IRQ_BEFOR_MRET `E203_PC_SIZE'h800000a6
+  `define PC_SFT_IRQ_BEFOR_MRET `E203_PC_SIZE'h800000be
+  `define PC_TMR_IRQ_BEFOR_MRET `E203_PC_SIZE'h800000d6
+  `define PC_AFTER_SETMTVEC     `E203_PC_SIZE'h8000015C
+
+  wire [`E203_XLEN-1:0] x3 = `EXU.u_e203_exu_regfile.rf_r[3];
+  wire [`E203_PC_SIZE-1:0] pc = `EXU.u_e203_exu_commit.alu_cmt_i_pc;
+  wire [`E203_PC_SIZE-1:0] pc_vld = `EXU.u_e203_exu_commit.alu_cmt_i_valid;
+
+  reg [31:0] pc_write_to_host_cnt;
+  reg [31:0] pc_write_to_host_cycle;
+  reg [31:0] valid_ir_cycle;
+  reg [31:0] cycle_count;
+  reg pc_write_to_host_flag;
+
+  always @(posedge clk or negedge rst_n)
+  begin 
+    if(rst_n == 1'b0) begin
+        pc_write_to_host_cnt <= 32'b0;
+        pc_write_to_host_flag <= 1'b0;
+        pc_write_to_host_cycle <= 32'b0;
+    end
+    else if (pc_vld & (pc == `PC_WRITE_TOHOST)) begin
+        pc_write_to_host_cnt <= pc_write_to_host_cnt + 1'b1;
+        pc_write_to_host_flag <= 1'b1;
+        if (pc_write_to_host_flag == 1'b0) begin
+            pc_write_to_host_cycle <= cycle_count;
+        end
+    end
+  end
+
+  always @(posedge clk or negedge rst_n)
+  begin 
+    if(rst_n == 1'b0) begin
+        cycle_count <= 32'b0;
+    end
+    else begin
+        cycle_count <= cycle_count + 1'b1;
+    end
+  end
+
+  wire i_valid = `EXU.i_valid;
+  wire i_ready = `EXU.i_ready;
+
+  always @(posedge clk or negedge rst_n)
+  begin 
+    if(rst_n == 1'b0) begin
+        valid_ir_cycle <= 32'b0;
+    end
+    else if(i_valid & i_ready & (pc_write_to_host_flag == 1'b0)) begin
+        valid_ir_cycle <= valid_ir_cycle + 1'b1;
+    end
+  end
+
+//`ifdef ENABLE_TB_FORCE
+//
+//  // Randomly force the external interrupt
+//  `define EXT_IRQ u_e203_soc_top.u_e203_subsys_top.u_e203_subsys_main.plic_ext_irq
+//  `define SFT_IRQ u_e203_soc_top.u_e203_subsys_top.u_e203_subsys_main.clint_sft_irq
+//  `define TMR_IRQ u_e203_soc_top.u_e203_subsys_top.u_e203_subsys_main.clint_tmr_irq
+//
+//  `define U_CPU u_e203_soc_top.u_e203_subsys_top.u_e203_subsys_main.u_e203_cpu_top.u_e203_cpu
+//  `define ITCM_BUS_ERR `U_CPU.u_e203_itcm_ctrl.sram_icb_rsp_err
+//  `define ITCM_BUS_READ `U_CPU.u_e203_itcm_ctrl.sram_icb_rsp_read
+//  `define STATUS_MIE   `U_CPU.u_e203_core.u_e203_exu.u_e203_exu_commit.u_e203_exu_excp.status_mie_r
+//
+//
+//  wire stop_assert_irq = (pc_write_to_host_cnt > 32);
+//
+//  reg tb_itcm_bus_err;
+//
+//  reg tb_ext_irq;
+//  reg tb_tmr_irq;
+//  reg tb_sft_irq;
+//  initial begin
+//    tb_ext_irq = 1'b0;
+//    tb_tmr_irq = 1'b0;
+//    tb_sft_irq = 1'b0;
+//  end
+//  initial begin
+//    tb_itcm_bus_err = 1'b0;
+//    #100
+//    @(pc == `PC_AFTER_SETMTVEC ) // Wait the program goes out the reset_vector program
+//    forever begin
+//      repeat ($urandom_range(1, 20)) @(posedge clk) tb_itcm_bus_err = 1'b0; // Wait random times
+//      repeat ($urandom_range(1, 200)) @(posedge clk) tb_itcm_bus_err = 1'b1; // Wait random times
+//      if(stop_assert_irq) begin
+//          break;
+//      end
+//    end
+//  end
+//
+//
+//  initial begin
+//    force `EXT_IRQ = tb_ext_irq;
+//    force `SFT_IRQ = tb_sft_irq;
+//    force `TMR_IRQ = tb_tmr_irq;
+//       // We force the bus-error only when:
+//       //   It is in common code, not in exception code, by checking MIE bit
+//       //   It is in read operation, not write, otherwise the test cannot recover
+//    force `ITCM_BUS_ERR = tb_itcm_bus_err
+//                        & `STATUS_MIE 
+//                        & `ITCM_BUS_READ
+//                        ;
+//  end
+//
+//
+//  initial begin
+//    #100
+//    @(pc == `PC_AFTER_SETMTVEC ) // Wait the program goes out the reset_vector program
+//    forever begin
+//      repeat ($urandom_range(1, 1000)) @(posedge clk) tb_ext_irq = 1'b0; // Wait random times
+//      tb_ext_irq = 1'b1; // assert the irq
+//      @((pc == `PC_EXT_IRQ_BEFOR_MRET)) // Wait the program run into the IRQ handler by check PC values
+//      tb_ext_irq = 1'b0;
+//      if(stop_assert_irq) begin
+//          break;
+//      end
+//    end
+//  end
+//
+//  initial begin
+//    #100
+//    @(pc == `PC_AFTER_SETMTVEC ) // Wait the program goes out the reset_vector program
+//    forever begin
+//      repeat ($urandom_range(1, 1000)) @(posedge clk) tb_sft_irq = 1'b0; // Wait random times
+//      tb_sft_irq = 1'b1; // assert the irq
+//      @((pc == `PC_SFT_IRQ_BEFOR_MRET)) // Wait the program run into the IRQ handler by check PC values
+//      tb_sft_irq = 1'b0;
+//      if(stop_assert_irq) begin
+//          break;
+//      end
+//    end
+//  end
+//
+////---->>>>
+//  initial begin
+//    #100
+//    @(pc == `PC_AFTER_SETMTVEC ) // Wait the program goes out the reset_vector program
+//    forever begin
+//      repeat ($urandom_range(1, 1000)) @(posedge clk) tb_tmr_irq = 1'b0; // Wait random times
+//      tb_tmr_irq = 1'b1; // assert the irq
+//      @((pc == `PC_TMR_IRQ_BEFOR_MRET)) // Wait the program run into the IRQ handler by check PC values
+//      tb_tmr_irq = 1'b0;
+//      if(stop_assert_irq) begin
+//          break;
+//      end
+//    end
+//  end
+//
+////  reg cpu_out_of_rst = 1'b0;
+////
+////  always @(posedge clk or negedge rst_n) begin
+////	  if (!rst_n)
+////		  cpu_out_of_rst <= 1'b0;
+////	  else if (pc == `PC_AFTER_SERMTVEC)
+////		  cpu_out_of_rst <= 1'b1;
+////  end
+////<<<<----
+//`endif
+
+  reg[8*64:1] testcase;
+//  integer dumpwave;
+
+  initial begin
+    $display("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");  
+    if($value$plusargs("TESTCASE=%s",testcase))begin
+      $display("TESTCASE=%s",testcase);
+    end
+    else begin
+	    $fatal(1,"No TESTCASE defined!");
+	    $finish;
+    end
+  end
+
+  always  @(pc_write_to_host_cnt) begin
+	  if (pc_write_to_host_cnt == 32'd8) begin
+//`ifdef ENABLE_TB_FORCE
+//    @((~tb_tmr_irq) & (~tb_sft_irq) & (~tb_ext_irq)) #10 rst_n <=1;// Wait the interrupt to complete
+//`endif
+
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~ Test Result Summary ~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~TESTCASE: %s ~~~~~~~~~~~~~", testcase);
+        $display("~~~~~~~~~~~~~~Total cycle_count value: %d ~~~~~~~~~~~~~", cycle_count);
+        $display("~~~~~~~~~~The valid Instruction Count: %d ~~~~~~~~~~~~~", valid_ir_cycle);
+        $display("~~~~~The test ending reached at cycle: %d ~~~~~~~~~~~~~", pc_write_to_host_cycle);
+        $display("~~~~~~~~~~~~~~~The final x3 Reg value: %d ~~~~~~~~~~~~~", x3);
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+    if (x3 == 1) begin
+        $display("~~~~~~~~~~~~~~~~ TEST_PASS ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~ #####     ##     ####    #### ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~ #    #   #  #   #       #     ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~ #    #  #    #   ####    #### ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~ #####   ######       #       #~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~ #       #    #  #    #  #    #~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~ #       #    #   ####    #### ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+    end
+    else begin
+        $display("~~~~~~~~~~~~~~~~ TEST_FAIL ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~######    ##       #    #     ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~#        #  #      #    #     ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~#####   #    #     #    #     ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~#       ######     #    #     ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~#       #    #     #    #     ~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~#       #    #     #    ######~~~~~~~~~~~~~~~~");
+        $display("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
+    end
+    $finish;
+    end
+  end
+
+  // watchdog
+  always @(posedge clk) begin
+    if (cycle_count[20] == 1'b1) begin
+      $error("Time Out !!!");
+      $finish;
+    end
+  end
+
+
+
+  
+  
+//  initial begin
+//    $value$plusargs("DUMPWAVE=%d",dumpwave);
+//    if(dumpwave != 0)begin
+//         // To add your waveform generation function
+//    end
+//  end
+
+
+
+
+
+  integer i;
+
+    reg [7:0] itcm_mem [0:(`E203_ITCM_RAM_DP*8)-1];
+    initial begin
+      $readmemh({testcase, ".verilog"}, itcm_mem);
+
+      for (i=0;i<(`E203_ITCM_RAM_DP);i=i+1) begin
+          `ITCM.mem_r[i][00+7:00] = itcm_mem[i*8+0];
+          `ITCM.mem_r[i][08+7:08] = itcm_mem[i*8+1];
+          `ITCM.mem_r[i][16+7:16] = itcm_mem[i*8+2];
+          `ITCM.mem_r[i][24+7:24] = itcm_mem[i*8+3];
+          `ITCM.mem_r[i][32+7:32] = itcm_mem[i*8+4];
+          `ITCM.mem_r[i][40+7:40] = itcm_mem[i*8+5];
+          `ITCM.mem_r[i][48+7:48] = itcm_mem[i*8+6];
+          `ITCM.mem_r[i][56+7:56] = itcm_mem[i*8+7];
+      end
+
+        $display("ITCM 0x00: %h", `ITCM.mem_r[8'h00]);
+        $display("ITCM 0x01: %h", `ITCM.mem_r[8'h01]);
+        $display("ITCM 0x02: %h", `ITCM.mem_r[8'h02]);
+        $display("ITCM 0x03: %h", `ITCM.mem_r[8'h03]);
+        $display("ITCM 0x04: %h", `ITCM.mem_r[8'h04]);
+        $display("ITCM 0x05: %h", `ITCM.mem_r[8'h05]);
+        $display("ITCM 0x06: %h", `ITCM.mem_r[8'h06]);
+        $display("ITCM 0x07: %h", `ITCM.mem_r[8'h07]);
+        $display("ITCM 0x16: %h", `ITCM.mem_r[8'h16]);
+        $display("ITCM 0x20: %h", `ITCM.mem_r[8'h20]);
+
+    end 
+
+
+
+  wire jtag_TDI = 1'b0;
+  wire jtag_TDO;
+  wire jtag_TCK = 1'b0;
+  wire jtag_TMS = 1'b0;
+  wire jtag_TRST = 1'b0;
+
+  wire jtag_DRV_TDO = 1'b0;
+
+
+e203_soc_top u_e203_soc_top(
+   
+   .hfextclk(clk),
+   .hfxoscen(),
+
+   .lfextclk(clk),
+   .lfxoscen(),
+
+   .io_pads_jtag_TCK_i_ival (jtag_TCK),
+   .io_pads_jtag_TMS_i_ival (jtag_TMS),
+   .io_pads_jtag_TDI_i_ival (jtag_TDI),
+   .io_pads_jtag_TDO_o_oval (jtag_TDO),
+   .io_pads_jtag_TDO_o_oe (),
+   .io_pads_gpio_0_i_ival (1'b1),
+   .io_pads_gpio_0_o_oval (),
+   .io_pads_gpio_0_o_oe (),
+   .io_pads_gpio_0_o_ie (),
+   .io_pads_gpio_0_o_pue (),
+   .io_pads_gpio_0_o_ds (),
+   .io_pads_gpio_1_i_ival (1'b1),
+   .io_pads_gpio_1_o_oval (),
+   .io_pads_gpio_1_o_oe (),
+   .io_pads_gpio_1_o_ie (),
+   .io_pads_gpio_1_o_pue (),
+   .io_pads_gpio_1_o_ds (),
+   .io_pads_gpio_2_i_ival (1'b1),
+   .io_pads_gpio_2_o_oval (),
+   .io_pads_gpio_2_o_oe (),
+   .io_pads_gpio_2_o_ie (),
+   .io_pads_gpio_2_o_pue (),
+   .io_pads_gpio_2_o_ds (),
+   .io_pads_gpio_3_i_ival (1'b1),
+   .io_pads_gpio_3_o_oval (),
+   .io_pads_gpio_3_o_oe (),
+   .io_pads_gpio_3_o_ie (),
+   .io_pads_gpio_3_o_pue (),
+   .io_pads_gpio_3_o_ds (),
+   .io_pads_gpio_4_i_ival (1'b1),
+   .io_pads_gpio_4_o_oval (),
+   .io_pads_gpio_4_o_oe (),
+   .io_pads_gpio_4_o_ie (),
+   .io_pads_gpio_4_o_pue (),
+   .io_pads_gpio_4_o_ds (),
+   .io_pads_gpio_5_i_ival (1'b1),
+   .io_pads_gpio_5_o_oval (),
+   .io_pads_gpio_5_o_oe (),
+   .io_pads_gpio_5_o_ie (),
+   .io_pads_gpio_5_o_pue (),
+   .io_pads_gpio_5_o_ds (),
+   .io_pads_gpio_6_i_ival (1'b1),
+   .io_pads_gpio_6_o_oval (),
+   .io_pads_gpio_6_o_oe (),
+   .io_pads_gpio_6_o_ie (),
+   .io_pads_gpio_6_o_pue (),
+   .io_pads_gpio_6_o_ds (),
+   .io_pads_gpio_7_i_ival (1'b1),
+   .io_pads_gpio_7_o_oval (),
+   .io_pads_gpio_7_o_oe (),
+   .io_pads_gpio_7_o_ie (),
+   .io_pads_gpio_7_o_pue (),
+   .io_pads_gpio_7_o_ds (),
+   .io_pads_gpio_8_i_ival (1'b1),
+   .io_pads_gpio_8_o_oval (),
+   .io_pads_gpio_8_o_oe (),
+   .io_pads_gpio_8_o_ie (),
+   .io_pads_gpio_8_o_pue (),
+   .io_pads_gpio_8_o_ds (),
+   .io_pads_gpio_9_i_ival (1'b1),
+   .io_pads_gpio_9_o_oval (),
+   .io_pads_gpio_9_o_oe (),
+   .io_pads_gpio_9_o_ie (),
+   .io_pads_gpio_9_o_pue (),
+   .io_pads_gpio_9_o_ds (),
+   .io_pads_gpio_10_i_ival (1'b1),
+   .io_pads_gpio_10_o_oval (),
+   .io_pads_gpio_10_o_oe (),
+   .io_pads_gpio_10_o_ie (),
+   .io_pads_gpio_10_o_pue (),
+   .io_pads_gpio_10_o_ds (),
+   .io_pads_gpio_11_i_ival (1'b1),
+   .io_pads_gpio_11_o_oval (),
+   .io_pads_gpio_11_o_oe (),
+   .io_pads_gpio_11_o_ie (),
+   .io_pads_gpio_11_o_pue (),
+   .io_pads_gpio_11_o_ds (),
+   .io_pads_gpio_12_i_ival (1'b1),
+   .io_pads_gpio_12_o_oval (),
+   .io_pads_gpio_12_o_oe (),
+   .io_pads_gpio_12_o_ie (),
+   .io_pads_gpio_12_o_pue (),
+   .io_pads_gpio_12_o_ds (),
+   .io_pads_gpio_13_i_ival (1'b1),
+   .io_pads_gpio_13_o_oval (),
+   .io_pads_gpio_13_o_oe (),
+   .io_pads_gpio_13_o_ie (),
+   .io_pads_gpio_13_o_pue (),
+   .io_pads_gpio_13_o_ds (),
+   .io_pads_gpio_14_i_ival (1'b1),
+   .io_pads_gpio_14_o_oval (),
+   .io_pads_gpio_14_o_oe (),
+   .io_pads_gpio_14_o_ie (),
+   .io_pads_gpio_14_o_pue (),
+   .io_pads_gpio_14_o_ds (),
+   .io_pads_gpio_15_i_ival (1'b1),
+   .io_pads_gpio_15_o_oval (),
+   .io_pads_gpio_15_o_oe (),
+   .io_pads_gpio_15_o_ie (),
+   .io_pads_gpio_15_o_pue (),
+   .io_pads_gpio_15_o_ds (),
+   .io_pads_gpio_16_i_ival (1'b1),
+   .io_pads_gpio_16_o_oval (),
+   .io_pads_gpio_16_o_oe (),
+   .io_pads_gpio_16_o_ie (),
+   .io_pads_gpio_16_o_pue (),
+   .io_pads_gpio_16_o_ds (),
+   .io_pads_gpio_17_i_ival (1'b1),
+   .io_pads_gpio_17_o_oval (),
+   .io_pads_gpio_17_o_oe (),
+   .io_pads_gpio_17_o_ie (),
+   .io_pads_gpio_17_o_pue (),
+   .io_pads_gpio_17_o_ds (),
+   .io_pads_gpio_18_i_ival (1'b1),
+   .io_pads_gpio_18_o_oval (),
+   .io_pads_gpio_18_o_oe (),
+   .io_pads_gpio_18_o_ie (),
+   .io_pads_gpio_18_o_pue (),
+   .io_pads_gpio_18_o_ds (),
+   .io_pads_gpio_19_i_ival (1'b1),
+   .io_pads_gpio_19_o_oval (),
+   .io_pads_gpio_19_o_oe (),
+   .io_pads_gpio_19_o_ie (),
+   .io_pads_gpio_19_o_pue (),
+   .io_pads_gpio_19_o_ds (),
+   .io_pads_gpio_20_i_ival (1'b1),
+   .io_pads_gpio_20_o_oval (),
+   .io_pads_gpio_20_o_oe (),
+   .io_pads_gpio_20_o_ie (),
+   .io_pads_gpio_20_o_pue (),
+   .io_pads_gpio_20_o_ds (),
+   .io_pads_gpio_21_i_ival (1'b1),
+   .io_pads_gpio_21_o_oval (),
+   .io_pads_gpio_21_o_oe (),
+   .io_pads_gpio_21_o_ie (),
+   .io_pads_gpio_21_o_pue (),
+   .io_pads_gpio_21_o_ds (),
+   .io_pads_gpio_22_i_ival (1'b1),
+   .io_pads_gpio_22_o_oval (),
+   .io_pads_gpio_22_o_oe (),
+   .io_pads_gpio_22_o_ie (),
+   .io_pads_gpio_22_o_pue (),
+   .io_pads_gpio_22_o_ds (),
+   .io_pads_gpio_23_i_ival (1'b1),
+   .io_pads_gpio_23_o_oval (),
+   .io_pads_gpio_23_o_oe (),
+   .io_pads_gpio_23_o_ie (),
+   .io_pads_gpio_23_o_pue (),
+   .io_pads_gpio_23_o_ds (),
+   .io_pads_gpio_24_i_ival (1'b1),
+   .io_pads_gpio_24_o_oval (),
+   .io_pads_gpio_24_o_oe (),
+   .io_pads_gpio_24_o_ie (),
+   .io_pads_gpio_24_o_pue (),
+   .io_pads_gpio_24_o_ds (),
+   .io_pads_gpio_25_i_ival (1'b1),
+   .io_pads_gpio_25_o_oval (),
+   .io_pads_gpio_25_o_oe (),
+   .io_pads_gpio_25_o_ie (),
+   .io_pads_gpio_25_o_pue (),
+   .io_pads_gpio_25_o_ds (),
+   .io_pads_gpio_26_i_ival (1'b1),
+   .io_pads_gpio_26_o_oval (),
+   .io_pads_gpio_26_o_oe (),
+   .io_pads_gpio_26_o_ie (),
+   .io_pads_gpio_26_o_pue (),
+   .io_pads_gpio_26_o_ds (),
+   .io_pads_gpio_27_i_ival (1'b1),
+   .io_pads_gpio_27_o_oval (),
+   .io_pads_gpio_27_o_oe (),
+   .io_pads_gpio_27_o_ie (),
+   .io_pads_gpio_27_o_pue (),
+   .io_pads_gpio_27_o_ds (),
+   .io_pads_gpio_28_i_ival (1'b1),
+   .io_pads_gpio_28_o_oval (),
+   .io_pads_gpio_28_o_oe (),
+   .io_pads_gpio_28_o_ie (),
+   .io_pads_gpio_28_o_pue (),
+   .io_pads_gpio_28_o_ds (),
+   .io_pads_gpio_29_i_ival (1'b1),
+   .io_pads_gpio_29_o_oval (),
+   .io_pads_gpio_29_o_oe (),
+   .io_pads_gpio_29_o_ie (),
+   .io_pads_gpio_29_o_pue (),
+   .io_pads_gpio_29_o_ds (),
+   .io_pads_gpio_30_i_ival (1'b1),
+   .io_pads_gpio_30_o_oval (),
+   .io_pads_gpio_30_o_oe (),
+   .io_pads_gpio_30_o_ie (),
+   .io_pads_gpio_30_o_pue (),
+   .io_pads_gpio_30_o_ds (),
+   .io_pads_gpio_31_i_ival (1'b1),
+   .io_pads_gpio_31_o_oval (),
+   .io_pads_gpio_31_o_oe (),
+   .io_pads_gpio_31_o_ie (),
+   .io_pads_gpio_31_o_pue (),
+   .io_pads_gpio_31_o_ds (),
+
+   .io_pads_qspi_sck_o_oval (),
+   .io_pads_qspi_dq_0_i_ival (1'b1),
+   .io_pads_qspi_dq_0_o_oval (),
+   .io_pads_qspi_dq_0_o_oe (),
+   .io_pads_qspi_dq_0_o_ie (),
+   .io_pads_qspi_dq_0_o_pue (),
+   .io_pads_qspi_dq_0_o_ds (),
+   .io_pads_qspi_dq_1_i_ival (1'b1),
+   .io_pads_qspi_dq_1_o_oval (),
+   .io_pads_qspi_dq_1_o_oe (),
+   .io_pads_qspi_dq_1_o_ie (),
+   .io_pads_qspi_dq_1_o_pue (),
+   .io_pads_qspi_dq_1_o_ds (),
+   .io_pads_qspi_dq_2_i_ival (1'b1),
+   .io_pads_qspi_dq_2_o_oval (),
+   .io_pads_qspi_dq_2_o_oe (),
+   .io_pads_qspi_dq_2_o_ie (),
+   .io_pads_qspi_dq_2_o_pue (),
+   .io_pads_qspi_dq_2_o_ds (),
+   .io_pads_qspi_dq_3_i_ival (1'b1),
+   .io_pads_qspi_dq_3_o_oval (),
+   .io_pads_qspi_dq_3_o_oe (),
+   .io_pads_qspi_dq_3_o_ie (),
+   .io_pads_qspi_dq_3_o_pue (),
+   .io_pads_qspi_dq_3_o_ds (),
+   .io_pads_qspi_cs_0_o_oval (),
+   .io_pads_aon_erst_n_i_ival (rst_n),//This is the real reset, active low
+   .io_pads_aon_pmu_dwakeup_n_i_ival (1'b1),
+
+   .io_pads_aon_pmu_vddpaden_o_oval (),
+    .io_pads_aon_pmu_padrst_o_oval    (),
+
+    .io_pads_bootrom_n_i_ival       (1'b0),// In Simulation we boot from ROM
+    .io_pads_dbgmode0_n_i_ival       (1'b1),
+    .io_pads_dbgmode1_n_i_ival       (1'b1),
+    .io_pads_dbgmode2_n_i_ival       (1'b1) 
+);
+ 
+
+endmodule

--- a/verilator/tb_verilator.v
+++ b/verilator/tb_verilator.v
@@ -1,3 +1,27 @@
+/*
+Copyright 2017 Silicon Integrated Microelectronics, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Changelog:
+
+  2018, Aug, Tomas Brabec
+  - Modified the testbench to work with Verilator (i.e. used only synthesis
+    like syntax. This also included using the same clock for `hfextclk` and
+    `lfextclk`.
+  - Commented out error injection.
+
+*/
 
 `include "e203_defines.v"
 


### PR DESCRIPTION
This pull requests adds a testbench and Makefile to run ISA tests against RTL with Verilator.

There are minor changes in RTL to make it work with Verilator. Minor changes also made in fpga and SDK Makefiles (these are not needed for the Verilator testbech).