### PR TITLE
Fix typo in decoder

### DIFF
--- a/rtl/e203/core/e203_exu_decode.v
+++ b/rtl/e203/core/e203_exu_decode.v
@@ -954,7 +954,7 @@ module e203_exu_decode(
             | ({`E203_DECINFO_WIDTH{amoldst_op}} & {{`E203_DECINFO_WIDTH-`E203_DECINFO_AGU_WIDTH{1'b0}},agu_info_bus})
             | ({`E203_DECINFO_WIDTH{bjp_op}}     & {{`E203_DECINFO_WIDTH-`E203_DECINFO_BJP_WIDTH{1'b0}},bjp_info_bus})
             | ({`E203_DECINFO_WIDTH{csr_op}}     & {{`E203_DECINFO_WIDTH-`E203_DECINFO_CSR_WIDTH{1'b0}},csr_info_bus})
-            | ({`E203_DECINFO_WIDTH{muldiv_op}}  & {{`E203_DECINFO_WIDTH-`E203_DECINFO_CSR_WIDTH{1'b0}},muldiv_info_bus})
+            | ({`E203_DECINFO_WIDTH{muldiv_op}}  & {{`E203_DECINFO_WIDTH-`E203_DECINFO_MULDIV_WIDTH{1'b0}},muldiv_info_bus})
               ;
 
 


### PR DESCRIPTION
muldiv info bus should use E203_DECINFO_MULDIV_WIDTH.